### PR TITLE
oVirt API version is checked

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -123,6 +123,8 @@ function printErrors(summary, errors) {
 function build(previousSizeMap) {
   console.log('Creating an optimized production build...');
   webpack(config).run((err, stats) => {
+    stats.compilation.warnings.length && printErrors('Warnings appeared during compilation.', stats.compilation.warnings);
+
     if (err) {
       printErrors('Failed to compile.', [err]);
       process.exit(1);
@@ -134,7 +136,8 @@ function build(previousSizeMap) {
     }
 
     if (process.env.CI && stats.compilation.warnings.length) {
-     printErrors('Failed to compile.', stats.compilation.warnings);
+//     printErrors('Failed to compile due to warnings', stats.compilation.warnings);
+     console.log('Failed to compile due to warnings.');   
      process.exit(1);
    }
 

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,11 @@ export const CONSOLE_TYPE_ID_MAP = { // TODO: replace by API call /vms/[ID]/grap
 
 export const CONSOLE_CLIENT_RESOURCES_URL = 'https://www.ovirt.org/documentation/admin-guide/virt/console-client-resources/'; // TODO: branding
 
+export const REQUIRED_OVIRT_API_VERSION = {
+  major: 4,
+  minor: 0, // TODO: do not commit, must be 0!
+};
+
 const CONFIG = { // will be dynamically replaced by content of CONFIG_FILE_URL within OVIRT_PROVIDER.init()
   /**
    * Set to false to turn off the debug logging

--- a/src/configFuncs.js
+++ b/src/configFuncs.js
@@ -1,4 +1,4 @@
-import { deferFunctionCall, logDebug, logError } from './helpers.js'
+import { /* deferFunctionCall, */ logDebug, logError } from './helpers.js'
 import { showPluginInstallationDialog } from './installDialog.js'
 import CONFIG, { CONFIG_FILE_URL } from './config.js'
 
@@ -22,7 +22,8 @@ export function readConfiguration (onConfigRead) {
       CONFIG.OVIRT_BASE_URL = baseUrl;
 
       logDebug(`Configuration parsed, using merged result: ${JSON.stringify(CONFIG)}`);
-      return deferFunctionCall(onConfigRead);
+      // return deferFunctionCall(onConfigRead);
+      return onConfigRead();
     }, (e) => { // AJAX failed
       if (e && e.status === 404) {
         logError(`Configuration of cockpit-machines-ovirt-provider not found. It means, the install script has not been called yet.`);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -25,7 +25,7 @@ export function deferFunctionCall ( func ) {
 export function ovirtApiGet (resource, custHeaders, failHandler) {
   const headers = Object.assign({}, {
       'Accept': 'application/json',
-      'Content-Type': 'application/xml',
+      'Content-Type': 'application/xml', // TODO: change to JSON after verification
       'Authorization': 'Bearer ' + CONFIG.token
     },
     custHeaders);

--- a/src/install.sh
+++ b/src/install.sh
@@ -67,7 +67,6 @@ function generateProviderConfig() {
 }
 
 function updateShellManifest() {
-  #SHELL_OVERRIDE=$(dirname $(dirname ${SCRIPT_DIR}))/shell/override.json
   SHELL_OVERRIDE=${COCKPIT_DIR}/shell/override.json
   if [ -f ${SHELL_OVERRIDE} ] ; then
     grep -iq 'content-security-policy' ${SHELL_OVERRIDE}
@@ -87,7 +86,6 @@ function updateShellManifest() {
 }
 
 function updateMachinesManifest() {
-  #MACHINES_OVERRIDE=$(dirname ${SCRIPT_DIR})/override.json
   MACHINES_OVERRIDE=${COCKPIT_DIR}/machines/override.json
   echo "{ \
       \"content-security-policy\": \"default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:;connect-src 'self' ws: wss: $ENGINE_URL\" \

--- a/src/installDialog.js
+++ b/src/installDialog.js
@@ -121,3 +121,15 @@ function getLogoutRequiredHtml() {
     '<strong>' + _("Installation finished successfuly.") + '</strong>' + _(" Please <b>re-login</b> to take effect.") +
   '</div>';
 }
+
+// This function might be elsewhere but let's keep JQuery-based stuff at one place
+export function showFailedOvirtApiVersionCheck (required) {
+  const html = '<div class="alert alert-danger">' +
+    '<span class="pficon pficon-error-circle-o"></span>' +
+    '<strong>' + _("oVirt API version check failed.") + '</strong>' +
+    _(" Minimal version required: ") +
+    '<strong>' + required.major + '.' + required.minor + '</strong>' +
+    '</div>';
+
+  $("body").append(html);
+}

--- a/src/login.js
+++ b/src/login.js
@@ -2,7 +2,7 @@ import { logDebug } from './helpers.js'
 import CONFIG from './config.js'
 import { toggleLoginInProgress } from './components/topLevelViewSwitch.jsx'
 
-export function doLogin () {
+export function doLogin (checkApiVersionFunc) {
   logDebug('_login() called')
 
   const baseUrl = CONFIG.OVIRT_BASE_URL
@@ -21,12 +21,12 @@ export function doLogin () {
     logDebug(`doLogin(): token from params stored to sessionStorage, now removing the token hash from the url`)
     window.top.location.hash = ''
 
-    return true
+    return checkApiVersionFunc()
   } else if (token) { // found in the sessionStorrage
     logDebug(`doLogin(): token found in sessionStorrage: ${token}`)
     CONFIG.token = token
     toggleLoginInProgress()
-    return true
+    return checkApiVersionFunc()
   } else { // redirect to oVirt's SSO
     const hostUrl = `https://${window.location.host}`
     const ssoUrl = `${baseUrl}/web-ui/authorizedRedirect.jsp?redirectUrl=${hostUrl}/machines/__hash__token=TOKEN`

--- a/src/ovirt.js
+++ b/src/ovirt.js
@@ -2,6 +2,7 @@ import { updateHost, removeUnlistedHosts, updateVm, removeUnlistedVms,
   updateTemplate, removeUnlistedTemplates, updateCluster, removeUnlistedClusters, downloadIcons } from './actions';
 import { callOncePerTimeperiod, logDebug, logError, ovirtApiGet } from './helpers';
 import CONFIG from './config';
+import { isOvirtApiCheckPassed } from './provider'
 
 let lastOvirtPoll = -1; // timestamp
 /**
@@ -10,6 +11,11 @@ let lastOvirtPoll = -1; // timestamp
  * @param dispatch
  */
 export function pollOvirt({dispatch}) {
+  if (!isOvirtApiCheckPassed()) {
+    logDebug(`Skipping oVirt poling due to failed/unfinished oVirt API check`);
+    return ;
+  }
+
   callOncePerTimeperiod({
     lastCall: lastOvirtPoll,
     delay: CONFIG.ovirt_polling_interval,

--- a/src/provider.js
+++ b/src/provider.js
@@ -29,7 +29,8 @@ import VmOverviewPropsComponents from './components/vmOverviewProperties.jsx';
 import VmConsoleComponents from './components/vmConsoleComponents.jsx';
 // import VmDisksSubtab from './components/vmDisksSubtab.jsx';
 import { appendClusterSwitch } from './components/topLevelViewSwitch.jsx';
-import { CONSOLE_TYPE_ID_MAP } from './config';
+import { CONSOLE_TYPE_ID_MAP, REQUIRED_OVIRT_API_VERSION } from './config';
+import { showFailedOvirtApiVersionCheck } from './installDialog'
 
 import { pollOvirt, forceNextOvirtPoll, oVirtIconToInternal } from './ovirt';
 
@@ -60,6 +61,7 @@ function buildVmFailHandler ({dispatch, vmName, msg, detailForNonexisting}) {
 let OVIRT_PROVIDER = {};
 OVIRT_PROVIDER = {
   name: 'oVirt',
+  ovirtApiMetadata: {}, // see checkApiVersion()
 
   actions: { // OVIRT_PROVIDER.actions is for reference only, it's expected to be replaced by init()
     virtMiddleware: (method, action) => {},
@@ -107,7 +109,7 @@ OVIRT_PROVIDER = {
     lazyCreateReactComponents();
     appendClusterSwitch(reduxStore);
 
-    return readConfiguration( doLogin );
+    return readConfiguration( () => doLogin(checkApiVersion) );
   },
 
   vmStateMap: null, // see init()
@@ -164,6 +166,11 @@ OVIRT_PROVIDER = {
    */
   SHUTDOWN_VM: (payload) => {
     logDebug(`SHUTDOWN_VM(payload: ${JSON.stringify(payload)})`);
+    if (!isOvirtApiCheckPassed()) {
+      logDebug('oVirt API version does not match, redirecting the action to Libvirt');
+      return OVIRT_PROVIDER.nextProvider.SHUTDOWN_VM(payload);
+    }
+
     const id = payload.id;
     const vmName = payload.name;
     forceNextOvirtPoll();
@@ -182,6 +189,11 @@ OVIRT_PROVIDER = {
    */
   FORCEOFF_VM: (payload) => {
     logDebug(`FORCEOFF_VM(payload: ${JSON.stringify(payload)})`);
+    if (!isOvirtApiCheckPassed()) {
+      logDebug('oVirt API version does not match, redirecting the action to Libvirt');
+      return OVIRT_PROVIDER.nextProvider.FORCEOFF_VM(payload);
+    }
+
     const id = payload.id;
     const vmName = payload.name;
     forceNextOvirtPoll();
@@ -194,6 +206,11 @@ OVIRT_PROVIDER = {
 
   REBOOT_VM: (payload) => {
     logDebug(`REBOOT_VM(payload: ${JSON.stringify(payload)})`);
+    if (!isOvirtApiCheckPassed()) {
+      logDebug('oVirt API version does not match, redirecting the action to Libvirt');
+      return OVIRT_PROVIDER.nextProvider.REBOOT_VM(payload);
+    }
+
     const vmName = payload.name;
     const id = payload.id;
     forceNextOvirtPoll();
@@ -211,6 +228,11 @@ OVIRT_PROVIDER = {
 
   START_VM: (payload) => {
     logDebug(`START_VM(payload: ${JSON.stringify(payload)})`);
+    if (!isOvirtApiCheckPassed()) {
+      logDebug('oVirt API version does not match, redirecting the action to Libvirt');
+      return OVIRT_PROVIDER.nextProvider.START_VM(payload);
+    }
+
     const id = payload.id;
     const vmName = payload.name;
     const hostName = payload.hostName; // optional
@@ -229,6 +251,11 @@ OVIRT_PROVIDER = {
 
   MIGRATE_VM: ({ vmId, vmName, hostId }) => {
     logDebug(`MIGRATE_VM(payload: {vmId: "${vmId}", hostId: "${hostId}"}`);
+    if (!isOvirtApiCheckPassed()) {
+      logDebug('oVirt API version does not match but the MIGRATE action is not supported by Libvirt provider, skipping' );
+      return () => {};
+    }
+
     const action = hostId ?
       `<action><host id="${hostId}"/></action>` :
       '<action/>';
@@ -268,7 +295,7 @@ OVIRT_PROVIDER = {
     const vmId = vm.id;
     const orig = vm.displays[type];
 
-    if (!isVmManagedByOvirt(OVIRT_PROVIDER.reduxStore.getState(), vmId)) {
+    if (!isVmManagedByOvirt(OVIRT_PROVIDER.reduxStore.getState(), vmId) || !isOvirtApiCheckPassed()) {
       return new Promise( (resolve, reject) => {
         resolve(orig);
       })
@@ -297,7 +324,7 @@ OVIRT_PROVIDER = {
     const vmId = payload.id;
     logDebug(`CONSOLE_VM: requesting .vv file from oVirt for vmId: ${vmId}, type: ${type}`);
 
-    if (!isVmManagedByOvirt(OVIRT_PROVIDER.reduxStore.getState(), vmId)) {
+    if (!isVmManagedByOvirt(OVIRT_PROVIDER.reduxStore.getState(), vmId) || !isOvirtApiCheckPassed()) {
       logDebug(`CONSOLE_VM: vmId: ${vmId} is not managed by oVirt, redirecting to Libvirt`);
       return OVIRT_PROVIDER.nextProvider.GET_VM(payload);
     }
@@ -324,6 +351,11 @@ OVIRT_PROVIDER = {
 
   CREATE_VM (payload) {
     logDebug(`CREATE_VM: payload = ${JSON.stringify(payload)}`);
+    if (!isOvirtApiCheckPassed()) {
+      logDebug('oVirt API version does not match, but CREATE_VM action is not supported by the Libvirt provider. Skipping.');
+      return () => {}
+    }
+
     const templateName = payload.templateName || 'blank'; // optional
     const clusterName = payload.clusterName || 'default'; // optional
     const { vm } = payload;
@@ -342,6 +374,11 @@ OVIRT_PROVIDER = {
 
   SUSPEND_VM ({ id, name }) {
     logDebug(`SUSPEND_VM(id=${id})`);
+    if (!isOvirtApiCheckPassed()) {
+      logDebug('oVirt API version does not match, but SUSPEND_VM action is not supported by the Libvirt provider. Skipping.');
+      return () => {}
+    }
+
     return (dispatch) => ovirtApiPost(
       `vms/${id}/suspend`,
       '<action><async>false</async></action>',
@@ -369,6 +406,7 @@ OVIRT_PROVIDER = {
 
   vmDisksActionsFactory: undefined,
   vmDisksColumns: undefined,
+
 /* Not needed now, keeping as an example
   vmDisksActionsFactory: ({vm}) => VmDisksSubtab.DummyActionsFactory({vm}), // listing-wide actions, see cockpit-components-listing.jsx
   vmDisksColumns: [
@@ -384,7 +422,60 @@ OVIRT_PROVIDER = {
     },
   ],
 */
-
 };
+
+function compareVersion (actual, required) {
+  logDebug(`compareVersion(), actual=${JSON.stringify(actual)}, required=${JSON.stringify(required)}`)
+
+  // assuming backward compatibility of oVirt API
+  if (actual.major >= required.major) {
+    if (actual.major === required.major) {
+      if (actual.minor < required.minor) {
+        return false
+      }
+    }
+    return true
+  }
+  return false
+}
+
+function checkApiVersion () {
+  logDebug('checkApiVersion() started');
+
+  const failHandler = (data, ex) => {
+    logError('checkApiVersion(): failed to load oVirt API metadata');
+    setOvirtApiCheckResult(false);
+  };
+
+  return ovirtApiGet(
+    ``, // just the /ovirt-engine/api
+    {},
+    failHandler
+  ).then(apiMetaData => {
+    logDebug('checkApiVersion() - API metadata retrieved: ', apiMetaData);
+
+    if (!(apiMetaData && apiMetaData['product_info'] && apiMetaData['product_info']['version'] &&
+      apiMetaData['product_info']['version']['major'] && apiMetaData['product_info']['version']['minor'])) {
+      console.error('Incompatible oVirt API version: ', apiMetaData)
+
+      setOvirtApiCheckResult(false);
+      return ;
+    }
+
+    const actual = apiMetaData['product_info']['version']
+    const passed = compareVersion({ major: parseInt(actual.major, 10), minor: parseInt(actual.minor, 10) }, REQUIRED_OVIRT_API_VERSION)
+    logDebug('checkApiVersion(): ', passed);
+    setOvirtApiCheckResult(passed);
+  })
+}
+
+function setOvirtApiCheckResult (passed) {
+  OVIRT_PROVIDER.ovirtApiMetadata.passed = passed;
+  showFailedOvirtApiVersionCheck(REQUIRED_OVIRT_API_VERSION)
+}
+
+export function isOvirtApiCheckPassed () {
+  return OVIRT_PROVIDER.ovirtApiMetadata.passed;
+}
 
 export default OVIRT_PROVIDER;


### PR DESCRIPTION
If the engine's version is lower than required (**recently 4.0**),
an error message is shown, the oVirt polling is skipped and
all oVirt actions are redirected back to just Libvirt.

Such redirected actions will fail on an oVirt host now due to not-yet
implemented authentication to Libvirt which is required on an oVirt host.

![apiversioncheckfailed](https://cloud.githubusercontent.com/assets/17194943/25987928/3c209c96-36f6-11e7-9aae-79220b69c23e.png)

_Please note, the actually required version is 4.0, the 4.3 value is from testing._

Fixes: #23 