### PR TITLE
Fix oVirt API version check

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -471,7 +471,9 @@ function checkApiVersion () {
 
 function setOvirtApiCheckResult (passed) {
   OVIRT_PROVIDER.ovirtApiMetadata.passed = passed;
-  showFailedOvirtApiVersionCheck(REQUIRED_OVIRT_API_VERSION)
+  if (!passed) {
+    showFailedOvirtApiVersionCheck(REQUIRED_OVIRT_API_VERSION)
+  }
 }
 
 export function isOvirtApiCheckPassed () {


### PR DESCRIPTION
Without this patch, the error message is always rendered
independently on the actual check result.